### PR TITLE
Fix variable default value bug

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-######################## 
+########################
+
+cd /home/joplin
 
 if [[ -f .joplinrc ]];then
     . .joplinrc
 fi
 
 APP_BASE_URL="${APP_BASE_URL:-https://joplin.me.org}"
-APP_PORT="${APP_BASE_URL:-22300}"
-DB_CLIENT="${APP_BASE_URL:-pg}"
-POSTGRES_PASSWORD="${APP_BASE_URL:-joplin}"
-POSTGRES_DATABASE="${APP_BASE_URL:-joplin}"
-POSTGRES_USER="${APP_BASE_URL:-joplin}"
-POSTGRES_PORT="${APP_BASE_URL:-5432}"
-POSTGRES_HOST="${APP_BASE_URL:-localhost}"
+APP_PORT="${APP_PORT:-22300}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-joplin}"
+DB_CLIENT="${DB_CLIENT:-pg}"
+POSTGRES_DATABASE="${POSTGRES_DATABASE:-joplin}"
+POSTGRES_USER="${POSTGRES_USER:-joplin}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
 
 export APP_BASE_URL APP_PORT=22300 DB_CLIENT POSTGRES_PASSWORD POSTGRES_DATABASE POSTGRES_USER POSTGRES_PORT POSTGRES_HOST
-
-cd /home/joplin
 
 npm --prefix packages/server start


### PR DESCRIPTION
Default values for most variables were clearly wrong (APP_BASE_URL) and the `cd` should be up front so as to contextualise the `.joplinrc` source.