### PR TITLE
favicon.ico was not being found

### DIFF
--- a/joplin-build.sh
+++ b/joplin-build.sh
@@ -47,6 +47,7 @@ npm run bootstrap
 # change.
 
 rsync -r joplin/packages/server/package*.json ./packages/server/
+cp joplin/Assets/WebsiteAssets/favicon.ico ./packages/server/public/
 npm run bootstrapServerOnly
 
 # Now copy the source files. Put lib and server last as they are more likely to change.
@@ -61,4 +62,3 @@ rsync -r joplin/packages/server/ ./packages/server/
 # Finally build everything, in particular the TypeScript files.
 
 npm run build
-


### PR DESCRIPTION
I'm not sure what else may be missing. But the server running reported it could not find favicon.ico. The only other asset it loaded was the Logo and by comparing the URL with the filesystem I can see where it's coming from, the public folder in the server package. Yet the favicon was in the WebAssets folder. Not sure why, and this is a one line copy of the asset over after the rsync. 

But it begs the question, what other assets may be missing!