### PR TITLE
Make sure $workdir exists

### DIFF
--- a/joplin.sh
+++ b/joplin.sh
@@ -37,6 +37,11 @@ checkout_latest(){
 }
 
 build(){
+    if [ ! -d "$WORKDIR" ]; then
+        mkdir -p $WORKDIR
+        echo "created " $WORKDIR
+        fi
+
     cd $WORKDIR
     COPY .yarn/plugins ./.yarn/plugins
     COPY .yarn/releases ./.yarn/releases


### PR DESCRIPTION
Just re-run the script on a clean Debian install for testing and noticed, that the $workdir never automaticly get's created.