### PR TITLE
copy newly reqired folder 'patches' before building

### DIFF
--- a/joplin.sh
+++ b/joplin.sh
@@ -40,6 +40,7 @@ build(){
     cd $WORKDIR
     COPY .yarn/plugins ./.yarn/plugins
     COPY .yarn/releases ./.yarn/releases
+    COPY .yarn/patches ./.yarn/patches
     COPY package.json .
     COPY .yarnrc.yml .
     COPY yarn.lock .


### PR DESCRIPTION
Running the 'joplin.sh build' command currently fails with the error below, because the folder 'patches' did not get copied to the build folder.


```
~$ ./joplin.sh build          
➤ YN0000: ┌ Resolution step
➤ YN0001: │ Error: eslint@patch:eslint@npm%3A8.39.0#./.yarn/patches/eslint-npm-8.39.0-d92bace04d.patch::locator=root%40workspace%3A.: ENOENT: no such file or directory, open '/home/joplin/build/.yarn/patches/eslint-npm-8.39.0-d92bace04d.patch'
➤ YN0000: └ Completed in 2s 446ms
➤ YN0000: Failed with errors in 2s 451ms
```
